### PR TITLE
GroupProduct entity implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,12 @@ repositories {
 
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springframework.boot:spring-boot-starter-web')
+    runtimeOnly('mysql:mysql-connector-java')
     runtimeOnly('com.h2database:h2')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/java/com/kodilla/ecommercee/entity/GroupProduct.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/GroupProduct.java
@@ -1,0 +1,23 @@
+package com.kodilla.ecommercee.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class GroupProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/com/kodilla/ecommercee/entity/ProductGroup.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/ProductGroup.java
@@ -6,13 +6,15 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class GroupProduct {
+public class ProductGroup {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,4 +22,10 @@ public class GroupProduct {
 
     @Column(nullable = false)
     private String name;
+
+    @Column
+    @OneToMany(mappedBy = "productGroup",
+                cascade = CascadeType.PERSIST,
+                fetch = FetchType.LAZY)
+    private List<ProductMock> products = new ArrayList<>();
 }

--- a/src/main/java/com/kodilla/ecommercee/entity/ProductMock.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/ProductMock.java
@@ -1,0 +1,23 @@
+package com.kodilla.ecommercee.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ProductMock {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "productgroup_id", nullable = false)
+    private ProductGroup productGroup;
+}

--- a/src/main/java/com/kodilla/ecommercee/entity/TestEntity.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/TestEntity.java
@@ -1,4 +1,0 @@
-package com.kodilla.ecommercee.entity;
-
-public class TestEntity {
-}


### PR DESCRIPTION
Co prawda tu powinna być relacja jeden-wiele z encją Product (od strony Product musi być), ale według mnie nie jest konieczna. Jeśli ktoś będzie chciał pobrać wszystkie produkty danej Grupy, wystarczy id Grupy. O ile wiem, relacje jednostronne są dopuszczalne.
Dodałem tez zmodyfikowanego Gradla, bo poprzednio zapomniałem i nie przechodził Circleci ze względu na brak Lomboka ...